### PR TITLE
Cannot run this project

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
   "dependencies": {
     "@material-ui/core": "^3.1.2",
     "@material-ui/icons": "^3.0.1",
+    "core-js": "^2.5.7",
     "gatsby": "2.0.18",
     "gatsby-plugin-manifest": "2.0.4",
     "gatsby-plugin-offline": "2.0.5",


### PR DESCRIPTION
Thanks for sharing this project.

Needed to add core-js to make the project run for me

```
error Cannot find module 'core-js/modules/es6.array.filter'


  Error: Cannot find module 'core-js/modules/es6.array.filter'
  
  - module.js:11 require
    internal/module.js:11:18
  
  - render-page.js:3 webpackUniversalModuleDefinition
    /Users/noccer/Dropbox/Niall/career/web_development/code/gatsby/gatsby-starter-material-ui/public/render-page.js:3:54
  
  - render-page.js:10 Object.<anonymous>
    /Users/noccer/Dropbox/Niall/career/web_development/code/gatsby/gatsby-starter-material-ui/public/render-page.js:10:3
  
  - module.js:11 require
    internal/module.js:11:18
  
  - worker.js:32 Promise
    [gatsby-starter-material-ui]/[gatsby]/dist/utils/worker.js:32:35
  
  - debuggability.js:313 Promise._execute
    [gatsby-starter-material-ui]/[bluebird]/js/release/debuggability.js:313:9
  
  - promise.js:483 Promise._resolveFromExecutor
    [gatsby-starter-material-ui]/[bluebird]/js/release/promise.js:483:18
  

error UNHANDLED REJECTION


  Error: Cannot find module 'core-js/modules/es6.array.filter'
  
  - module.js:11 require
    internal/module.js:11:18
  
  - render-page.js:3 webpackUniversalModuleDefinition
    /Users/noccer/Dropbox/Niall/career/web_development/code/gatsby/gatsby-starter-material-ui/public/render-page.js:3:54
  
  - render-page.js:10 Object.<anonymous>
    /Users/noccer/Dropbox/Niall/career/web_development/code/gatsby/gatsby-starter-material-ui/public/render-page.js:10:3
  
  - module.js:11 require
    internal/module.js:11:18
  
  - worker.js:32 Promise
    [gatsby-starter-material-ui]/[gatsby]/dist/utils/worker.js:32:35
  
  - debuggability.js:313 Promise._execute
    [gatsby-starter-material-ui]/[bluebird]/js/release/debuggability.js:313:9
  
  - promise.js:483 Promise._resolveFromExecutor
    [gatsby-starter-material-ui]/[bluebird]/js/release/promise.js:483:18
```

MacOS
Node 8.11.2
npm 6.4.1